### PR TITLE
Swift 3 segmentation fault

### DIFF
--- a/NTPKit/NTPServer.h
+++ b/NTPKit/NTPServer.h
@@ -36,8 +36,12 @@ NS_ASSUME_NONNULL_BEGIN
 //! Disconnects from the NTP server.
 - (void)disconnect NS_REQUIRES_SUPER;
 
+- (BOOL)sync;
+
 //! Attempts to perform an NTP sync request.
 - (BOOL)syncWithError:(NSError *__autoreleasing _Nonnull *_Nullable)error NS_REQUIRES_SUPER;
+
+- (nullable NSDate *)date;
 
 //! Returns the NTP date based on the last sync request.
 - (nullable NSDate *)dateWithError:(NSError *__autoreleasing _Nonnull *_Nullable)error;

--- a/NTPKit/NTPServer.m
+++ b/NTPKit/NTPServer.m
@@ -181,6 +181,11 @@ static ufixed64_t ntp_localtime_get_ufixed64() {
     }
 }
 
+- (BOOL)sync {
+    NSError *error;
+    return [self syncWithError:&error];
+}
+
 - (BOOL)syncWithError:(NSError * _Nonnull __autoreleasing *)error {
     @synchronized (self) {
         if (![self connectWithError:error]) {
@@ -229,6 +234,12 @@ static ufixed64_t ntp_localtime_get_ufixed64() {
         _offset = ((T[1] - T[0]) + (T[2] - T[3])) / 2.0;
         return YES;
     }
+}
+
+- (nullable NSDate *)date
+{
+    NSError *error;
+    return [self dateWithError:&error];
 }
 
 - (nullable NSDate *)dateWithError:(NSError * _Nonnull __autoreleasing *)error {


### PR DESCRIPTION
Add sync and date method without error to avoid segmentation fault 11 when compiling the class in a swift 3 project
